### PR TITLE
ProcessRequest and ProcessResponse work with *void | server and clien…

### DIFF
--- a/src/HSMP.hpp
+++ b/src/HSMP.hpp
@@ -5,138 +5,19 @@
 #include <exception>
 #include <stdlib.h>
 #include <vector>
+#include <string.h>
+
+struct BroadcastResponse {};
+
+class User {
+ public:
+  std::string ip;
+  std::string user_name;
+  std::string user_password;
+  User(std::string ip,std::string user_name,std::string user_password): ip(ip), user_name(user_name), user_password(user_password){}
+};
 
 namespace HSMP {
-
-enum RequestType {
-  kLoginRequest,
-  kListaRequest,
-  kMessageRequest,
-  kBroadcastRequest,
-  kUploadFileRequest,
-  kFile_ANRequest,
-  kExitRequest
-};
-
-struct ClientRequest {
-  char accion;
-
-  ClientRequest(char action, RequestType type) : accion(action), _type(type) {}
-
-  virtual ~ClientRequest() {};
-
-  RequestType type() const {
-    return _type;
-  };
-
-  virtual void PrintStructure() const {};
-
- private:
-  RequestType _type;
-};
-
-struct LoginRequest : ClientRequest {
-  short int tam_user;
-  short int tam_passwd;
-  std::string user;
-  std::string passwd;
-
-  LoginRequest() : ClientRequest('l', kLoginRequest) {}
-  ~LoginRequest() {}
-
-  void PrintStructure() const {
-    std::cout << "LoginRequest:\n";
-    std::cout << "\ttam_user: " << this->tam_user << "\n";
-    std::cout << "\ttam_passwd: " << this->tam_passwd << "\n";
-    std::cout << "\tuser: " << this->user << "\n";
-    std::cout << "\tpasswd: " << this->passwd << std::endl;
-  }
-};
-
-struct ListaRequest : ClientRequest {
-  ListaRequest() : ClientRequest('i', kListaRequest) {}
-  ~ListaRequest() {}
-
-  void PrintStructure() const {
-    std::cout << "ListaRequest" << std::endl;
-  }
-};
-
-struct MessageRequest : ClientRequest {
-  short int tam_msg;
-  short int tam_destinatario;
-  std::string msg;
-  std::string destinatario;
-
-  MessageRequest() : ClientRequest('m', kMessageRequest) {}
-  ~MessageRequest() {}
-
-  void PrintStructure() const {
-    std::cout << "MessageRequest:\n";
-    std::cout << "\ttam_msg: " << this->tam_msg << "\n";
-    std::cout << "\ttam_destinatario: " << this->tam_destinatario << "\n";
-    std::cout << "\tmsg: " << this->msg << "\n";
-    std::cout << "\tdestinatario: " << this->destinatario << std::endl;
-  }
-};
-
-struct BroadcastRequest : ClientRequest {
-  short int tam_msg;
-  std::string msg;
-
-  BroadcastRequest() : ClientRequest('b', kBroadcastRequest) {}
-  ~BroadcastRequest() {}
-
-  void PrintStructure() const {
-    std::cout << "BroadcastRequest:\n";
-    std::cout << "\tmensaje tam: " << this->tam_msg << "\n";
-    std::cout << "\tmensaje: " << this->msg << std::endl;
-  }
-};
-
-struct UploadFileRequest : ClientRequest {
-  short int tam_file_name;
-  short int tam_file_data;
-  short int tam_destinatario;
-  std::string file_name;
-  char* file_data; // castear segun es imagen/video/etc
-  std::string destinatario;
-
-  UploadFileRequest() : ClientRequest('u', kUploadFileRequest) {}
-  ~UploadFileRequest() {}
-
-  void PrintStructure() const {
-    std::cout << "UploadFileRequest:\n";
-    std::cout << "\tfile nombre tam: " << this->tam_file_name << "\n";
-    std::cout << "\tfile nombre: " << this->file_name << "\n";
-    std::cout << "\tfile tam: " << this->tam_file_data << "\n";
-    std::cout << "\tdestinatario tam: " << this->tam_destinatario << "\n";
-    std::cout << "\tdestinatario : " << this->destinatario << std::endl;
-  }
-};
-
-struct File_ANRequest : ClientRequest {
-  short int tam_remitente;
-  std::string remitente;
-
-  File_ANRequest() : ClientRequest('f', kFile_ANRequest) {}
-  ~File_ANRequest() {}
-
-  void PrintStructure() const {
-    std::cout << "File_ANRequest:\n";
-    std::cout << "\ttam_remitente: " << this->tam_remitente << "\n";
-    std::cout << "\tremitente: " << this->remitente << std::endl;
-  }
-};
-
-struct ExitRequest : ClientRequest {
-  ExitRequest() : ClientRequest('x', kExitRequest) {}
-  ~ExitRequest() {}
-
-  void PrintStructure() const {
-    std::cout << "ExitRequest" << std::endl;
-  }
-};
 
 enum ResponseType {
   kLoginResponse,
@@ -161,6 +42,8 @@ struct ServerResponse {
   };
 
   virtual void PrintStructure() const {};
+  virtual void ParseToCharBuffer() {};
+
 
  private:
   ResponseType _type;
@@ -229,26 +112,91 @@ struct BroadcastResponse : ServerResponse {
     std::cout << "\tremitente tam: " << this->tam_remitente << "\n";
     std::cout << "\tremitente: " << this->remitente << std::endl;
   }
+
+  void ParseToCharBuffer() override {
+    // first part of header
+    std::string to_server ("B");
+    if (this->msg.length() <= 99) {
+      to_server+="0";
+      if (this->msg.length() <= 9) {
+        to_server+="0";
+      }
+    }
+    // second part of header
+    to_server += std::to_string(this->msg.length());
+
+    // third part of header
+    if (this->remitente.length() <= 9) {
+        to_server+="0";
+    }
+    to_server += std::to_string(this->remitente.length());
+    
+    // quarter part, body
+    to_server += msg + remitente;
+
+    // preparing to send
+    char buffer[1003];
+    std::size_t length = to_server.copy(buffer,to_server.length(),0);
+    buffer[length]='\0';
+
+    // uncomment to know what we are sending
+    std::cout << "to send: " << buffer << std::endl; 
+
+  }
 };
 
 struct UploadFileResponse : ServerResponse {
-  short int tama_file_name;
+  short int tam_file_name;
   short int tam_file_data;
   short int tam_remitente;
   std::string file_name;
   std::string remitente;
-  std::string file_data; // castear segun es imagen/video/etc
+  std::string file_data; // castear according to imagen/video/etc
 
   UploadFileResponse() : ServerResponse('U', kUploadFileResponse) {}
   ~UploadFileResponse(){}
 
   void PrintStructure() const {
     std::cout << "UploadFileResponse:\n";
-    std::cout << "\tfile tam: " << this->tama_file_name << "\n";
+    std::cout << "\tfile name tam: " << this->tam_file_name << "\n";
     std::cout << "\tfile: " << this-> file_name << "\n";
     std::cout << "\tfile tam: " << this-> tam_file_data << "\n";
+    std::cout << "\tfile_data: " << this-> file_data << "\n";
     std::cout << "\tremitente tam: " << this-> tam_remitente << "\n";
     std::cout << "\tremitente: " << this->remitente << std::endl;
+  }
+
+  void ParseToCharBuffer() override {
+    // first part of header
+    std::string to_server ("U");
+
+    // second part of header
+    if (this->file_name.length() <= 99) {
+      to_server+="0";
+      if (this->file_name.length() <= 9) {
+        to_server+="0";
+      }
+    }
+    to_server += std::to_string(this->file_name.length());
+
+    // third part of header
+    to_server += std::to_string(this->file_data.length());
+    to_server.insert(to_server.begin()+4,14-to_server.length(),'0');
+
+    // quarter part of header
+    if (this->remitente.length() <= 9) {
+        to_server+="0";
+    }
+    to_server += std::to_string(this->remitente.length());
+
+    // adding body
+    to_server += file_name + file_data + remitente;
+    char buffer[1003]; // it should be 16 + 999 + (10 times 9) + 99
+    std::size_t length = to_server.copy(buffer,to_server.length(),0);
+    buffer[length]='\0';
+
+    // uncomment to know what we are sending
+    std::cout << "to send: " << buffer << std::endl; 
   }
 
 };
@@ -288,8 +236,221 @@ struct ErrorResponse : ServerResponse {
   }
 };
 
+enum RequestType {
+  kLoginRequest,
+  kListaRequest,
+  kMessageRequest,
+  kBroadcastRequest,
+  kUploadFileRequest,
+  kFile_ANRequest,
+  kExitRequest
+};
 
-std::shared_ptr<ClientRequest> ProcessRequest(std::string buffer) {
+struct ClientRequest {
+  char accion;
+
+  ClientRequest(char action, RequestType type) : accion(action), _type(type) {}
+
+  virtual ~ClientRequest() {};
+
+  RequestType type() const {
+    return _type;
+  };
+
+  virtual void PrintStructure() const {};
+  virtual char *ParseToCharBuffer() {return nullptr;};
+  virtual void ProcessThisRequest(std::shared_ptr<std::list<User>> users) {};
+
+ private:
+  RequestType _type;
+};
+
+struct LoginRequest : ClientRequest {
+  short int tam_user;
+  short int tam_passwd;
+  std::string user;
+  std::string passwd;
+
+  LoginRequest() : ClientRequest('l', kLoginRequest) {}
+  ~LoginRequest() {}
+
+  void PrintStructure() const {
+    std::cout << "LoginRequest:\n";
+    std::cout << "\ttam_user: " << this->tam_user << "\n";
+    std::cout << "\ttam_passwd: " << this->tam_passwd << "\n";
+    std::cout << "\tuser: " << this->user << "\n";
+    std::cout << "\tpasswd: " << this->passwd << std::endl;
+  }
+};
+
+struct ListaRequest : ClientRequest {
+  ListaRequest() : ClientRequest('i', kListaRequest) {}
+  ~ListaRequest() {}
+
+  void PrintStructure() const {
+    std::cout << "ListaRequest" << std::endl;
+  }
+};
+
+struct MessageRequest : ClientRequest {
+  short int tam_msg;
+  short int tam_destinatario;
+  std::string msg;
+  std::string destinatario;
+
+  MessageRequest() : ClientRequest('m', kMessageRequest) {}
+  ~MessageRequest() {}
+
+  void PrintStructure() const {
+    std::cout << "MessageRequest:\n";
+    std::cout << "\ttam_msg: " << this->tam_msg << "\n";
+    std::cout << "\ttam_destinatario: " << this->tam_destinatario << "\n";
+    std::cout << "\tmsg: " << this->msg << "\n";
+    std::cout << "\tdestinatario: " << this->destinatario << std::endl;
+  }
+};
+
+struct BroadcastRequest : ClientRequest {
+  short int tam_msg;
+  std::string msg;
+
+  BroadcastRequest() : ClientRequest('b', kBroadcastRequest) {}
+  ~BroadcastRequest() {}
+
+  void PrintStructure() const {
+    std::cout << "BroadcastRequest:\n";
+    std::cout << "\tmensaje tam: " << this->tam_msg << "\n";
+    std::cout << "\tmensaje: " << this->msg << std::endl;
+  }
+
+  char *ParseToCharBuffer() override {
+    // first part of header
+    std::string to_server ("b");
+    if (this->msg.length() <= 99) {
+      to_server+="0";
+      if (this->msg.length() <= 9) {
+        to_server+="0";
+      }
+    }
+    // second part of header + body
+    to_server += std::to_string(this->msg.length()) + this->msg;
+
+    char *buffer= new char[to_server.length() + 1];
+    std::size_t length = to_server.copy(buffer,to_server.length(),0);
+    buffer[length]='\0';
+
+    // Uncomment to know what we are sending
+    //std::cout << "\tBroadcast sending to server: " << buffer << std::endl; 
+
+    return buffer;
+  }
+  
+  void ProcessThisRequest(std::shared_ptr<std::list<User>> users) override {
+    auto response = std::make_shared<BroadcastResponse>();
+    std::list<User>::iterator it=users->begin();
+    std::string remitente = it->user_name;
+    ++it;
+    for (; it != users->end(); ++it) {
+      std::cout << "user to send: " << it->user_name << std::endl;
+      response->msg = this->msg;
+      response->remitente = remitente;
+      response->ParseToCharBuffer();
+    }
+  }
+
+};
+
+struct UploadFileRequest : ClientRequest {
+  short int tam_file_name;
+  short int tam_file_data;
+  short int tam_destinatario;
+  std::string file_name;
+  std::string file_data; // castear segun es imagen/video/etc
+  std::string destinatario;
+
+  UploadFileRequest() : ClientRequest('u', kUploadFileRequest) {}
+  ~UploadFileRequest() {}
+
+  void PrintStructure() const {
+    std::cout << "UploadFileRequest:\n";
+    std::cout << "\tfile nombre tam: " << this->tam_file_name << "\n";
+    std::cout << "\tfile nombre: " << this->file_name << "\n";
+    std::cout << "\tfile tam: " << this->tam_file_data << "\n";
+    std::cout << "\tdestinatario tam: " << this->file_data << "\n";
+    std::cout << "\ftam_destinatario: " << this->tam_destinatario << "\n";
+    std::cout << "\tdestinatario : " << this->destinatario << std::endl;
+  }
+  
+  char *ParseToCharBuffer() override {
+    // first part of header
+    std::string to_server ("u");
+
+    // second part of header
+    if (this->file_name.length() <= 99) {
+      to_server+="0";
+      if (this->file_name.length() <= 9) {
+        to_server+="0";
+      }
+    }
+    to_server += std::to_string(this->file_name.length());
+
+    // third part of header
+    to_server += std::to_string(this->file_data.length());
+    to_server.insert(to_server.begin()+4,14-to_server.length(),'0');
+
+    // quarter part of header
+    if (this->destinatario.length() <= 9) {
+        to_server+="0";
+    }
+    to_server += std::to_string(this->destinatario.length());
+
+    // adding body
+    to_server += file_name + file_data + destinatario;
+    char *buffer= new char[to_server.length() + 1];
+    std::size_t length = to_server.copy(buffer,to_server.length(),0);
+    buffer[length]='\0';
+
+    // uncomment to know what we are sending
+    //std::cout << "\tUploadFileRequest sending to server: " << buffer << std::endl; 
+
+    return buffer;
+  }
+  
+  void ProcessThisRequest(std::shared_ptr<std::list<User>> users) override {
+    std::string who_do_request = "miguel"; // this have to be dinamically
+    auto response = std::make_shared<UploadFileResponse>();
+    response->file_name = this->file_name;
+    response->remitente = who_do_request;
+    response->file_data = this->file_data;
+    response->ParseToCharBuffer();
+  }
+};
+
+struct File_ANRequest : ClientRequest {
+  short int tam_remitente;
+  std::string remitente;
+
+  File_ANRequest() : ClientRequest('f', kFile_ANRequest) {}
+  ~File_ANRequest() {}
+
+  void PrintStructure() const {
+    std::cout << "File_ANRequest:\n";
+    std::cout << "\ttam_remitente: " << this->tam_remitente << "\n";
+    std::cout << "\tremitente: " << this->remitente << std::endl;
+  }
+};
+
+struct ExitRequest : ClientRequest {
+  ExitRequest() : ClientRequest('x', kExitRequest) {}
+  ~ExitRequest() {}
+
+  void PrintStructure() const {
+    std::cout << "ExitRequest" << std::endl;
+  }
+};
+
+std::shared_ptr<ClientRequest> ProcessRequest (const void *request) {
+  std::string buffer((char*)request);
   char action = buffer[0];
 
   switch (action) {
@@ -338,7 +499,7 @@ std::shared_ptr<ClientRequest> ProcessRequest(std::string buffer) {
       ureq->tam_destinatario = atoi(buffer.substr(14, 2).c_str());
 
       ureq->file_name = buffer.substr(16, ureq->tam_file_name);
-      //ureq->fileDataContenido; // depende el archivo
+      ureq->file_data = buffer.substr(16+ ureq->tam_file_name,ureq->tam_file_data); // depende el archivo
       ureq->destinatario = buffer.substr(16 + ureq->tam_file_name + ureq->tam_file_data, ureq->tam_destinatario);
       return ureq;
     }
@@ -362,7 +523,8 @@ std::shared_ptr<ClientRequest> ProcessRequest(std::string buffer) {
   }
 }
 
-std::shared_ptr<ServerResponse> ProcessResponse(std::string buffer) {
+std::shared_ptr<ServerResponse> ProcessResponse (const void *response) {
+  std::string buffer((char*)response);
   char action = buffer[0];
 
   switch (action) {
@@ -399,6 +561,31 @@ std::shared_ptr<ServerResponse> ProcessResponse(std::string buffer) {
       return Mres;
     }
 
+    case 'B': {
+      auto Mres = std::make_shared<BroadcastResponse>();
+
+      Mres->tam_msg = atoi(buffer.substr(1, 3).c_str());
+      Mres->tam_remitente = atoi(buffer.substr(4, 2).c_str());
+      
+      Mres->msg = buffer.substr(6, Mres->tam_msg);
+      Mres->remitente = buffer.substr(6 + Mres->tam_msg, Mres->tam_remitente);
+      
+      return Mres;
+    }
+
+    case 'U': {
+      auto Mres = std::make_shared<UploadFileResponse>();
+
+      Mres->tam_file_name = atoi(buffer.substr(1, 3).c_str());
+      Mres->tam_file_data = atoi(buffer.substr(4, 10).c_str());
+      Mres->tam_remitente = atoi(buffer.substr(14, 2).c_str());
+
+      Mres->file_name = buffer.substr(16, Mres->tam_file_name);
+      Mres->file_data = buffer.substr(16+ Mres->tam_file_name,Mres->tam_file_data); // depende el archivo
+      Mres->remitente = buffer.substr(16 + Mres->tam_file_name + Mres->tam_file_data, Mres->tam_remitente);
+      return Mres;
+    }
+
     case 'F': {
       auto Fres = std::make_shared<File_ANResponse>();
       Fres->tam_user_name = atoi(buffer.substr(1, 2).c_str());
@@ -421,24 +608,58 @@ std::shared_ptr<ServerResponse> ProcessResponse(std::string buffer) {
       return nullptr;
   }
 }
-// static void ProcessResponse(char* buffer); //read -->
-// static void SendRequest(std::string request);// --> write
-// static void SendResponse(std::string response);
-//
-// static void ProcessLoginRequest();
-// static void ProcessListaRequest();
-// static void ProcessMessageRequest();
-// static void ProcessBroadcastRequest();
-// static void ProcessUploadFileRequest();
-// static void ProcessFile_ANRequest();
-// static void ProcessExitRequest();
-//
-// static void ProcessLoginResponse();
-// static void ProcessListaResponse();
-// static void ProcessMessageResponse();
-// static void ProcessBroadcastResponse();
-// static void ProcessUploadFileResponse();
-// static void ProcessFile_ANResponse();
-// static void ProcessExitResponse();
-// static void ProcessErrorResponse();
+
+std::shared_ptr<ClientRequest> CreateRequest(){
+
+  // TODO
+  // infinite while for create diferente request without execute ./hsmp client
+
+  char accion;
+  printf("What do you want to do? [l] [i] [m] [b] [u] [x]\n");
+  std::cin >> accion;
+  std::cin.ignore();
+
+switch (accion) {
+  case 'b':
+  {
+    auto breq = std::make_shared<HSMP::BroadcastRequest>();
+    std::cout << "Creando Broadcast Request" << '\n';
+
+    char msgs[999];
+    std::cout << "what is the message to send: ";
+    std::cin.getline(msgs,999,'\n');
+    breq->msg = std::string(msgs);
+
+    return breq;
+  }
+  case 'u':
+  {
+    auto ureq = std::make_shared<HSMP::UploadFileRequest>();
+    std::cout << "Creando UploadFile Request" << '\n';
+
+    char buffer_name_file[999];
+    std::cout << "what is the file'name: ";
+    std::cin.getline(buffer_name_file,999,'\n');
+    ureq->file_name = std::string(buffer_name_file);
+
+    char buffer_data_file[999]; // it should be 10 times 9
+    std::cout << "what is the file'data: ";
+    std::cin.getline(buffer_data_file,999,'\n');
+    ureq->file_data = std::string(buffer_data_file);
+
+    char buffer_name_receptor[99];
+    std::cout << "what is the receptor'name: ";
+    std::cin.getline(buffer_name_receptor,999,'\n');
+    ureq->destinatario = std::string(buffer_name_receptor);
+
+    return ureq; 
+  }
+  default:
+  {
+    std::cout << "wrong input" << std::endl;
+    return nullptr;
+  }
+  }
+}
+
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,147 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <unistd.h>
+
 #include <iostream>
+#include <list>
+#include <vector>
+#include <map>
 #include <memory>
+
 #include "HSMP.hpp"
 
-int main() {
+typedef void (*function_ptr)();
+std::map<std::string, function_ptr> hsmp_commands;
+
+// first initial user to test
+auto firsts_users = {User("127.0.0.1","Joaquin","gaa"),User("127.0.0.1","Mateo","gee"),User("127.0.0.1","Miguel","gii"),};
+auto users = std::make_shared<std::list<User>>(firsts_users);
+
+// TODO
+// Way to identify who is send request because some of response is necessary
+
+void SendRequest(char *buffer) {
+  int sock;
+  char send_data[1024];
+  struct sockaddr_in server_addr;
+  struct hostent *host;
+  int n;
+
+  //host = (struct hostent *)gethostbyname((char *)"34.74.78.79"); // Mateo's host
+  host = (struct hostent *)gethostbyname((char *)"127.0.0.1");
+  if ((sock = socket(AF_INET, SOCK_DGRAM, 0)) == -1)
+  {
+    perror("socket");
+    exit(1);
+  }
+
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = htons(5000);
+  server_addr.sin_addr = *((struct in_addr *)host->h_addr);
+  bzero(&(server_addr.sin_zero), 8);
+
+  n = sendto(sock, buffer, strlen(buffer), 0, (struct sockaddr *)&server_addr, sizeof(struct sockaddr));
+
+}
+
+void client(){
+
+  // One thread client -> server
+  auto req = std::shared_ptr<HSMP::ClientRequest>();
+  req = HSMP::CreateRequest();
+  char *buffer_ready_to_send = req->ParseToCharBuffer();
+  SendRequest(buffer_ready_to_send);
+  
+  // Other thread async server -> client
+  //std::shared_ptr<HSMP::ServerResponse> res;
+  //res = HSMP::ProcessResponse("B01003HolaATodosLee");
+  //res->PrintStructure();
+
+}
+
+void server() {
+
+  int sock;
+  ssize_t bytes_read, len = 1024;
+  socklen_t *addr_len;
+  struct sockaddr_in server_addr, client_addr;
+
+  if ((sock = socket(AF_INET, SOCK_DGRAM, 0)) == -1) {
+    perror("Socket");
+    exit(1);
+  }
+
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = htons(5000);
+  server_addr.sin_addr.s_addr = INADDR_ANY;
+  bzero(&(server_addr.sin_zero), 8);
+
+  if (bind(sock, (struct sockaddr *)&server_addr, sizeof(struct sockaddr)) == -1) {
+    perror("Bind");
+    exit(1);
+  }
+
+  char *recv_data = new char[9999];
+
+  printf("\n HSMP Waiting for client");
+  fflush(stdout);
+
   std::shared_ptr<HSMP::ClientRequest> req;
 
-  req=  HSMP::ProcessRequest("l1104santistebanucsp");
+  while (1) {
+    bytes_read = recvfrom(sock, recv_data, 1024, 0, (struct sockaddr *)&client_addr, addr_len);
+    recv_data[bytes_read] = '\0';
+    printf("\n(%s , %d) said : ", inet_ntoa(client_addr.sin_addr), ntohs(client_addr.sin_port));
+    
+    // HSMP SERVER working
+    req = HSMP::ProcessRequest(recv_data);
+    req->PrintStructure();
+    // TODO
+    // We need something that prevent wrong request
+    req->ProcessThisRequest(users); // maybe is necessary pass who is the request doing, do you need it? me(Miguel) yes.
+    // HSMP SERVER working
+
+    bzero(recv_data,9999);
+    fflush(stdout);
+  }
+}
+
+void PrintHelp() {
+  std::cout << "USE ./hsmp server or ./hsmp client\n";
+}
+
+int main(int argc, char *argv[])
+{
+  hsmp_commands["client"] = &client;
+  hsmp_commands["server"] = &server;
+
+  if(argc == 1) {
+    PrintHelp();
+  }
+  else if(argc == 2){
+    std::string command = argv[1];
+    if (hsmp_commands.count(command)) {
+      (*hsmp_commands[command])();
+    }
+    else {
+      PrintHelp();
+    }
+  }
+  else {
+    PrintHelp();
+  }
+  return 0;
+
+  // previous main
+  /*
+  std::shared_ptr<HSMP::ClientRequest> req;
+
+  req = HSMP::ProcessRequest("l1104santistebanucsp");
   req->PrintStructure();
 
   req = HSMP::ProcessRequest("i");
@@ -20,6 +156,12 @@ int main() {
   req = HSMP::ProcessRequest("x");
   req->PrintStructure();
 
+  req = HSMP::ProcessRequest("b010HolaATodos");
+  req->PrintStructure();
+
+  req = HSMP::ProcessRequest("u006000000001005MiFotoDataDeFotoPeter");
+  req->PrintStructure();
+
   std::shared_ptr<HSMP::ServerResponse> res;
 
   res = HSMP::ProcessResponse("Lok");
@@ -31,11 +173,11 @@ int main() {
   res = HSMP::ProcessResponse("M00305byemateo");
   res->PrintStructure();
 
-  res = HSMP::ProcessResponse(""); //Broadcast
-  // res->PrintStructure();
-  
-  res = HSMP::ProcessResponse(""); // Upload
-  // res->PrintStructure();
+  res = HSMP::ProcessResponse("B01003HolaATodosLee"); //Broadcast
+  res->PrintStructure();
+
+  res = HSMP::ProcessResponse("U006000000001005MiFotoDataDeFotoPeter"); // Upload
+  res->PrintStructure();
 
   res = HSMP::ProcessResponse("F05mateo");
   res->PrintStructure();
@@ -45,6 +187,7 @@ int main() {
 
   res = HSMP::ProcessResponse("EThis is a Error Message");
   res->PrintStructure();
+  */
 
   return 0;
 }


### PR DESCRIPTION
- ProcessRequest and ProcessResponse work with *void #12 
- server and client function implemented udp-based 
- swap positions between ClientResquest and ServerResponse 
- ParseToChar() method implemented, return char* ready to put on write function #16 
- ProcessThisRequest() implemented on ClientRequest (as virtual function) to automatically generate ServerResponse and send(), but this send() is not implemented 
- CreateRequest() function implemented for easy use for client, is necessary put others ClientRequest 
- SendRequest() function to received like parameter char* #17 
- some TODO's
- Users demos created